### PR TITLE
new packages: utils & namespaces

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,6 +25,7 @@
     "@types/uuid": "^8.3.0"
   },
   "dependencies": {
+    "interop-namespaces": "^0.1.0",
     "interop-utils": "^0.1.0",
     "n3": "^1.10.0",
     "uuid": "^8.3.2"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -25,6 +25,7 @@
     "@types/uuid": "^8.3.0"
   },
   "dependencies": {
+    "interop-utils": "^0.1.0",
     "n3": "^1.10.0",
     "uuid": "^8.3.2"
   }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import { INTEROP } from 'interop-namespaces'
 
 import { Fetch } from './fetch';
-import { getAllMatchingQuads, getOneMatchingQuad, getRdfResource } from './rdf-functions';
+import { getAllMatchingQuads, getOneMatchingQuad } from 'interop-utils';
+import { getRdfResource } from './rdf-functions';
 import { parseRegistrySets, sha256 } from './interop-functions';
 
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,8 +1,9 @@
 import * as RDFJS from 'rdf-js';
 import * as path from 'path';
+import { INTEROP } from 'interop-namespaces'
 
 import { Fetch } from './fetch';
-import { getAllMatchingQuads, getOneMatchingQuad, getRdfResource, INTEROP } from './rdf-functions';
+import { getAllMatchingQuads, getOneMatchingQuad, getRdfResource } from './rdf-functions';
 import { parseRegistrySets, sha256 } from './interop-functions';
 
 
@@ -34,9 +35,9 @@ export class InteropClient {
   public async checkRegistration(): Promise<boolean> {
     // TODO(angel) don't re-fetch the profile document if it's already in-memory/cached somewhere
     const profileDocument = await getRdfResource(this.options.webId, this.fetch);
-    const registrySetUrl = getOneMatchingQuad(profileDocument as unknown as RDFJS.Dataset, null, INTEROP('hasApplicationRegistrySet')).object.value;
+    const registrySetUrl = getOneMatchingQuad(profileDocument as unknown as RDFJS.Dataset, null, INTEROP.hasApplicationRegistrySet).object.value;
     const registrySet = await getRdfResource(registrySetUrl, this.fetch);
-    const registryUrls = getAllMatchingQuads(registrySet as unknown as RDFJS.Dataset, null, INTEROP('hasRegistry')).map(q => q.object.value);
+    const registryUrls = getAllMatchingQuads(registrySet as unknown as RDFJS.Dataset, null, INTEROP.hasRegistry).map(q => q.object.value);
 
     for (const registry of registryUrls) {
       const response = await this.fetch(path.join(registry, await sha256(this.options.applicationWebId)))

--- a/packages/client/src/interop-functions.ts
+++ b/packages/client/src/interop-functions.ts
@@ -1,8 +1,9 @@
 import * as RDFJS from 'rdf-js';
 import * as N3 from 'n3';
 import * as uuid from 'uuid';
+import { INTEROP } from 'interop-namespaces'
 import { RegistrySet } from './storage';
-import { getOneMatchingQuad, INTEROP, RDF } from './rdf-functions';
+import { getOneMatchingQuad } from './rdf-functions';
 import { DataFactory } from 'n3';
 
 const { quad, namedNode, literal } = DataFactory;
@@ -12,11 +13,11 @@ const { quad, namedNode, literal } = DataFactory;
  * @param document RDF Graph of the document where the user webId is located
  */
 export const parseRegistrySets = (document: RDFJS.Dataset): RegistrySet => {
-    const application = getOneMatchingQuad(document, null, INTEROP('hasApplicationRegistrySet')).object.value;
-    const data = getOneMatchingQuad(document, null, INTEROP('hasDataRegistrySet')).object.value;
-    const accessGrant = getOneMatchingQuad(document, null, INTEROP('hasAccessGrantRegistrySet')).object.value;
-    const accessReceipt = getOneMatchingQuad(document, null, INTEROP('hasAccessReceiptRegistrySet')).object.value;
-    const remoteData = getOneMatchingQuad(document, null, INTEROP('hasRemoteDataRegistrySet')).object.value;
+    const application = getOneMatchingQuad(document, null, INTEROP.hasApplicationRegistrySet).object.value;
+    const data = getOneMatchingQuad(document, null, INTEROP.hasDataRegistrySet).object.value;
+    const accessGrant = getOneMatchingQuad(document, null, INTEROP.hasAccessGrantRegistrySet).object.value;
+    const accessReceipt = getOneMatchingQuad(document, null, INTEROP.hasAccessReceiptRegistrySet).object.value;
+    const remoteData = getOneMatchingQuad(document, null, INTEROP.hasRemoteDataRegistrySet).object.value;
 
     return { application, data, accessGrant, accessReceipt, remoteData };
 }

--- a/packages/client/src/interop-functions.ts
+++ b/packages/client/src/interop-functions.ts
@@ -1,9 +1,9 @@
 import * as RDFJS from 'rdf-js';
 import * as N3 from 'n3';
 import * as uuid from 'uuid';
+import { getOneMatchingQuad } from 'interop-utils';
 import { INTEROP } from 'interop-namespaces'
 import { RegistrySet } from './storage';
-import { getOneMatchingQuad } from './rdf-functions';
 import { DataFactory } from 'n3';
 
 const { quad, namedNode, literal } = DataFactory;

--- a/packages/client/src/rdf-functions.ts
+++ b/packages/client/src/rdf-functions.ts
@@ -1,4 +1,4 @@
-import * as RDFJS from 'rdf-js';
+import { DatasetCore } from 'rdf-js';
 import { Fetch } from './fetch';
 import { parseTurtle } from 'interop-utils';
 
@@ -7,7 +7,7 @@ import { parseTurtle } from 'interop-utils';
  * @param url Location of the RDF document
  * @param fetch Fetch function to use
  */
-export const getRdfResource = async (url: string, fetch: Fetch): Promise<RDFJS.Store> => {
+export const getRdfResource = async (url: string, fetch: Fetch): Promise<DatasetCore> => {
     const options = {
         method: 'get',
         headers: new Headers({

--- a/packages/client/src/rdf-functions.ts
+++ b/packages/client/src/rdf-functions.ts
@@ -47,13 +47,3 @@ export const getOneMatchingQuad = (dataset: RDFJS.Dataset, subject?: RDFJS.Term,
 export const getAllMatchingQuads = (dataset: RDFJS.Dataset, subject?: RDFJS.Term, predicate?: RDFJS.Term, object?: RDFJS.Term): Array<RDFJS.Quad> => {
     return [...dataset.match(subject, predicate, object)];
 }
-
-export const INTEROP = (prop: string): RDFJS.NamedNode => {
-    const base = 'http://www.w3.org/ns/solid/interop#';
-    return new N3.NamedNode(base + prop);
-}
-
-export const RDF = (prop: string): RDFJS.NamedNode => {
-    const base = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
-    return new N3.NamedNode(base + prop);
-}

--- a/packages/client/src/rdf-functions.ts
+++ b/packages/client/src/rdf-functions.ts
@@ -1,5 +1,4 @@
 import * as RDFJS from 'rdf-js';
-import * as N3 from 'n3';
 import { Fetch } from './fetch';
 import { parseTurtle } from 'interop-utils';
 
@@ -23,27 +22,4 @@ export const getRdfResource = async (url: string, fetch: Fetch): Promise<RDFJS.S
     }
     const store = await parseTurtle(await r.text());
     return Promise.resolve(store);
-}
-
-/**
- *
- * @param dataset
- * @param subject
- * @param predicate
- * @param object
- * @param graph
- */
-export const getOneMatchingQuad = (dataset: RDFJS.Dataset, subject?: RDFJS.Term, predicate?: RDFJS.Term, object?: RDFJS.Term, graph?: RDFJS.Term): RDFJS.Quad => {
-    // TODO(angel) unsure if the usage of the graph param is correct here
-    const matches = dataset.match(subject, predicate, object, graph);
-
-    if (matches.size === 0) {
-        throw new Error('Could not find matching quad in the dataset');
-    } else {
-        return [...matches].shift();
-    }
-}
-
-export const getAllMatchingQuads = (dataset: RDFJS.Dataset, subject?: RDFJS.Term, predicate?: RDFJS.Term, object?: RDFJS.Term): Array<RDFJS.Quad> => {
-    return [...dataset.match(subject, predicate, object)];
 }

--- a/packages/client/src/rdf-functions.ts
+++ b/packages/client/src/rdf-functions.ts
@@ -1,6 +1,7 @@
 import * as RDFJS from 'rdf-js';
 import * as N3 from 'n3';
 import { Fetch } from './fetch';
+import { parseTurtle } from 'interop-utils';
 
 /**
  * Retrieves and parses the content of the URL into an RDF store
@@ -20,34 +21,8 @@ export const getRdfResource = async (url: string, fetch: Fetch): Promise<RDFJS.S
     if (!r.ok) {
         throw Error('Request to pod server failed');
     }
-    const store = await parse(await r.text());
+    const store = await parseTurtle(await r.text());
     return Promise.resolve(store);
-}
-
-/**
- * Wrapper around N3.Parser.parse to convert from callback style to Promise.
- * @param text Text to parse. Either Turtle, N-Triples or N-Quads.
- */
-
-
-export const parse = async (text: string): Promise<N3.Store> => { //FIXME DatasetCore n3 needs to update its types
-    // TODO(angel) investigate what is the difference between Store and Dataset
-    const store = new N3.Store();
-    return new Promise((resolve, reject) => {
-        const parser = new N3.Parser()
-        // TODO(angel) better error handling?
-        parser.parse(text, (error: Error, quad: RDFJS.Quad, prefixes: N3.Prefixes) => {
-            if (error) {
-                reject(error);
-            }
-            if (quad) {
-                //@ts-ignore FIXME
-                store.add(quad);
-            } else {
-                resolve(store);
-            }
-        });
-    });
 }
 
 /**

--- a/packages/data-model/src/data-registration.ts
+++ b/packages/data-model/src/data-registration.ts
@@ -1,19 +1,16 @@
-import { Store } from 'n3'
+import { DatasetCore } from 'rdf-js'
+import { getOneMatchingQuad } from 'interop-utils'
 import { INTEROP } from 'interop-namespaces'
 
 export class DataRegistration {
-  dataset: Store //FIXME DatasetCore n3 needs to update their types
+  dataset: DatasetCore
   registeredShapeTree: string
 
-  constructor(dataset: Store) { //FIXME DatasetCore n3 needs to update their types
+  constructor(dataset: DatasetCore) {
     this.dataset = dataset
-    const matches =  this.dataset.match(
-      null,
-      INTEROP.registeredShapeTree,
-      null,
-      null
-      )
-    //@ts-ignore FIXME n3 needs to update their types
-    this.registeredShapeTree = [...matches][0].object.value
+
+    const quadPattern = [ null, INTEROP.registeredShapeTree, null, null ]
+    this.registeredShapeTree = getOneMatchingQuad(this.dataset, ...quadPattern).object.value
+
   }
 }

--- a/packages/data-model/src/data-registration.ts
+++ b/packages/data-model/src/data-registration.ts
@@ -1,4 +1,5 @@
-import { Store, DataFactory } from 'n3'
+import { Store } from 'n3'
+import { INTEROP } from 'interop-namespaces'
 
 export class DataRegistration {
   dataset: Store //FIXME DatasetCore n3 needs to update their types
@@ -8,7 +9,7 @@ export class DataRegistration {
     this.dataset = dataset
     const matches =  this.dataset.match(
       null,
-      DataFactory.namedNode('http://www.w3.org/ns/solid/interop#registeredShapeTree'),
+      INTEROP.registeredShapeTree,
       null,
       null
       )

--- a/packages/data-model/test/data-registration-test.ts
+++ b/packages/data-model/test/data-registration-test.ts
@@ -1,4 +1,4 @@
-import { parse } from 'interop-client'
+import { parseTurtle } from 'interop-utils'
 import { DataRegistration } from '../src/data-registration'
 
 
@@ -17,7 +17,7 @@ const snippet = `
 `
 
 test('DataRegistration has registeredShapeTree', async () => {
-  const dataset = await parse(snippet)
+  const dataset = await parseTurtle(snippet)
   const registration = new DataRegistration(dataset)
   expect(registration.registeredShapeTree).toEqual('https://solidshapes.example/trees/Project')
 })

--- a/packages/namespaces/jest.config.js
+++ b/packages/namespaces/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.json'
+    }
+  }
+};

--- a/packages/namespaces/package.json
+++ b/packages/namespaces/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "interop-data-model",
+  "name": "interop-namespaces",
   "version": "0.1.0",
   "description": "> TODO: description",
   "author": "Ángel Araya <angel.araya@janeirodigital.com>",
@@ -16,9 +16,20 @@
     "clean": "rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "interop-utils": "^0.1.0",
-    "interop-namespaces": "^0.1.0",
     "n3": "^1.10.0"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "../../tsconfig.json"
+      }
+    },
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "/test/.*-test.ts$",
+    "moduleFileExtensions": [ "js", "ts" ],
+    "collectCoverage": false
   },
   "devDependencies": {
     "@types/n3": "^1.8.0"

--- a/packages/namespaces/package.json
+++ b/packages/namespaces/package.json
@@ -18,19 +18,6 @@
   "dependencies": {
     "n3": "^1.10.0"
   },
-  "jest": {
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "../../tsconfig.json"
-      }
-    },
-    "transform": {
-      "^.+\\.ts$": "ts-jest"
-    },
-    "testRegex": "/test/.*-test.ts$",
-    "moduleFileExtensions": [ "js", "ts" ],
-    "collectCoverage": false
-  },
   "devDependencies": {
     "@types/n3": "^1.8.0"
   }

--- a/packages/namespaces/src/builder.ts
+++ b/packages/namespaces/src/builder.ts
@@ -1,10 +1,7 @@
 import { DataFactory } from 'n3'
 
 const handler = {
-  //@ts-ignore FIXME
-  apply: (target, thisArg, args) => target(args[0]),
-  //@ts-ignore FIXME
-  get: (target: object, property) => target(property)
+  get: (target: Function, property: string) => target(property)
 }
 
 export function buildNamespace (baseIRI: string) {

--- a/packages/namespaces/src/builder.ts
+++ b/packages/namespaces/src/builder.ts
@@ -1,0 +1,14 @@
+import { DataFactory } from 'n3'
+
+const handler = {
+  //@ts-ignore FIXME
+  apply: (target, thisArg, args) => target(args[0]),
+  //@ts-ignore FIXME
+  get: (target: object, property) => target(property)
+}
+
+export function buildNamespace (baseIRI: string) {
+  const builder = (term = '') => DataFactory.namedNode(`${baseIRI}${term}`)
+
+  return typeof Proxy === 'undefined' ? builder : new Proxy(builder, handler)
+}

--- a/packages/namespaces/src/index.ts
+++ b/packages/namespaces/src/index.ts
@@ -1,0 +1,3 @@
+import { buildNamespace } from './builder'
+
+export const INTEROP = buildNamespace('http://www.w3.org/ns/solid/interop#')

--- a/packages/namespaces/src/index.ts
+++ b/packages/namespaces/src/index.ts
@@ -1,3 +1,4 @@
 import { buildNamespace } from './builder'
+export { buildNamespace } from './builder'
 
 export const INTEROP = buildNamespace('http://www.w3.org/ns/solid/interop#')

--- a/packages/namespaces/tsconfig.json
+++ b/packages/namespaces/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+  },
+  "include": [ "src" ]
+}

--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.json'
+    }
+  }
+};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "interop-data-model",
+  "name": "interop-utils",
   "version": "0.1.0",
   "description": "> TODO: description",
   "author": "Ángel Araya <angel.araya@janeirodigital.com>",
@@ -16,8 +16,20 @@
     "clean": "rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "interop-utils": "^0.1.0",
     "n3": "^1.10.0"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "tsconfig": "../../tsconfig.json"
+      }
+    },
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "/test/.*-test.ts$",
+    "moduleFileExtensions": [ "js", "ts" ],
+    "collectCoverage": false
   },
   "devDependencies": {
     "@types/n3": "^1.8.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,19 +18,6 @@
   "dependencies": {
     "n3": "^1.10.0"
   },
-  "jest": {
-    "globals": {
-      "ts-jest": {
-        "tsconfig": "../../tsconfig.json"
-      }
-    },
-    "transform": {
-      "^.+\\.ts$": "ts-jest"
-    },
-    "testRegex": "/test/.*-test.ts$",
-    "moduleFileExtensions": [ "js", "ts" ],
-    "collectCoverage": false
-  },
   "devDependencies": {
     "@types/n3": "^1.8.0"
   }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from './turtle-parser'
+export * from './match'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './turtle-parser'

--- a/packages/utils/src/match.ts
+++ b/packages/utils/src/match.ts
@@ -1,0 +1,23 @@
+import { Term, Quad, DatasetCore} from 'rdf-js';
+
+/**
+ *
+ * @param dataset
+ * @param subject
+ * @param predicate
+ * @param object
+ * @param graph
+ */
+export const getOneMatchingQuad = (dataset: DatasetCore, subject?: Term, predicate?: Term, object?: Term, graph?: Term): Quad => {
+    const matches = dataset.match(subject, predicate, object, graph);
+
+    if (matches.size === 0) {
+        throw new Error('Could not find matching quad in the dataset');
+    } else {
+        return [...matches].shift();
+    }
+}
+
+export const getAllMatchingQuads = (dataset: DatasetCore, subject?: Term, predicate?: Term, object?: Term, graph?: Term): Array<Quad> => {
+    return [...dataset.match(subject, predicate, object, graph)];
+}

--- a/packages/utils/src/turtle-parser.ts
+++ b/packages/utils/src/turtle-parser.ts
@@ -1,5 +1,5 @@
 import { Quad, DatasetCore } from 'rdf-js'
-import { Store, Parser, Prefixes} from 'n3'
+import { Store, Parser, Prefixes, DataFactory } from 'n3'
 
 /**
  * Wrapper around N3.Parser.parse to convert from callback style to Promise.
@@ -7,7 +7,7 @@ import { Store, Parser, Prefixes} from 'n3'
  */
 
 
-export const parseTurtle = async (text: string): Promise<DatasetCore> => {
+export const parseTurtle = async (text: string, source?: string): Promise<DatasetCore> => {
     // TODO(angel) investigate what is the difference between Store and Dataset
     const store = new Store();
     return new Promise((resolve, reject) => {
@@ -18,6 +18,9 @@ export const parseTurtle = async (text: string): Promise<DatasetCore> => {
                 reject(error);
             }
             if (quad) {
+                if (source) {
+                    quad = DataFactory.quad(quad.subject, quad.predicate, quad.object, DataFactory.namedNode(source))
+                }
                 //@ts-ignore FIXME
                 store.add(quad);
             } else {

--- a/packages/utils/src/turtle-parser.ts
+++ b/packages/utils/src/turtle-parser.ts
@@ -1,0 +1,28 @@
+import * as RDFJS from 'rdf-js'
+import * as N3 from 'n3'
+
+/**
+ * Wrapper around N3.Parser.parse to convert from callback style to Promise.
+ * @param text Text to parse. Either Turtle, N-Triples or N-Quads.
+ */
+
+
+export const parseTurtle = async (text: string): Promise<N3.Store> => { //FIXME DatasetCore n3 needs to update its types
+    // TODO(angel) investigate what is the difference between Store and Dataset
+    const store = new N3.Store();
+    return new Promise((resolve, reject) => {
+        const parser = new N3.Parser()
+        // TODO(angel) better error handling?
+        parser.parse(text, (error: Error, quad: RDFJS.Quad, prefixes: N3.Prefixes) => {
+            if (error) {
+                reject(error);
+            }
+            if (quad) {
+                //@ts-ignore FIXME
+                store.add(quad);
+            } else {
+                resolve(store);
+            }
+        });
+    });
+}

--- a/packages/utils/src/turtle-parser.ts
+++ b/packages/utils/src/turtle-parser.ts
@@ -1,5 +1,5 @@
-import * as RDFJS from 'rdf-js'
-import * as N3 from 'n3'
+import { Quad, DatasetCore } from 'rdf-js'
+import { Store, Parser, Prefixes} from 'n3'
 
 /**
  * Wrapper around N3.Parser.parse to convert from callback style to Promise.
@@ -7,13 +7,13 @@ import * as N3 from 'n3'
  */
 
 
-export const parseTurtle = async (text: string): Promise<N3.Store> => { //FIXME DatasetCore n3 needs to update its types
+export const parseTurtle = async (text: string): Promise<DatasetCore> => {
     // TODO(angel) investigate what is the difference between Store and Dataset
-    const store = new N3.Store();
+    const store = new Store();
     return new Promise((resolve, reject) => {
-        const parser = new N3.Parser()
+        const parser = new Parser()
         // TODO(angel) better error handling?
-        parser.parse(text, (error: Error, quad: RDFJS.Quad, prefixes: N3.Prefixes) => {
+        parser.parse(text, (error: Error, quad: Quad, prefixes: Prefixes) => {
             if (error) {
                 reject(error);
             }
@@ -21,6 +21,7 @@ export const parseTurtle = async (text: string): Promise<N3.Store> => { //FIXME 
                 //@ts-ignore FIXME
                 store.add(quad);
             } else {
+                //@ts-ignore FIXME
                 resolve(store);
             }
         });

--- a/packages/utils/test/turtle-parser-test.ts
+++ b/packages/utils/test/turtle-parser-test.ts
@@ -1,0 +1,30 @@
+import { parseTurtle } from '../src/turtle-parser'
+
+const snippet = `
+  @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+  @prefix interop: <http://www.w3.org/ns/solid/interop#> .
+  @prefix solidtrees: <https://solidshapes.example/trees/> .
+  @prefix acme: <https://acme.example/> .
+  acme:4d594c61-7cff-484a-a1d2-1f353ee4e1e7
+    a interop:DataRegistration ;
+    interop:registeredBy <https://garry.example/#id> ;
+    interop:registeredWith <https://solidmin.example/#app> ;
+    interop:registeredAt "2020-08-23T21:12:27.000Z"^^xsd:dateTime ;
+    interop:registeredShapeTree solidtrees:Project .
+`
+
+
+test('uses DefaultGraph by default', async () => {
+  const dataset = await parseTurtle(snippet)
+  for (const quad of dataset) {
+    expect(quad.graph.termType).toEqual('DefaultGraph')
+  }
+})
+
+test('uses source as graph name if given', async () => {
+  const source = 'https://acme.example/4d594c61-7cff-484a-a1d2-1f353ee4e1e7'
+  const dataset = await parseTurtle(snippet, source)
+  for (const quad of dataset) {
+    expect(quad.graph.value).toEqual(source)
+  }
+})

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+  },
+  "include": [ "src" ]
+}


### PR DESCRIPTION
I moved most helpers from client to utils, namespace builder and common namespaces got their own package.

Also turtle parser now allows setting the graph name for all the quads.

Tomorrow I hope to resolve issues around RDFJS type definitions and N3Store, this PR still ignores errors related to it.