### PR TITLE
latest RDFJS types

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,8 +20,8 @@
     "clean": "rimraf dist tsconfig.tsbuildinfo"
   },
   "devDependencies": {
-    "@types/n3": "^1.8.0",
-    "@types/rdf-js": "^4.0.1",
+    "@rdfjs/types": "^1.0.1",
+    "@types/n3": "^1.10.0",
     "@types/uuid": "^8.3.0"
   },
   "dependencies": {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 // TODO (angel) re-enable eslint once this file is in a more stable place
-import * as RDFJS from 'rdf-js';
+import * as RDFJS from '@rdfjs/types';
 import * as path from 'path';
 import { INTEROP } from 'interop-namespaces';
 import { getAllMatchingQuads, getOneMatchingQuad } from 'interop-utils';

--- a/packages/client/src/interop-functions.ts
+++ b/packages/client/src/interop-functions.ts
@@ -1,4 +1,4 @@
-import * as RDFJS from 'rdf-js';
+import * as RDFJS from '@rdfjs/types';
 import { getOneMatchingQuad } from 'interop-utils';
 import { INTEROP } from 'interop-namespaces';
 import { RegistrySet } from './storage';

--- a/packages/client/src/rdf-functions.ts
+++ b/packages/client/src/rdf-functions.ts
@@ -1,4 +1,4 @@
-import { DatasetCore } from 'rdf-js';
+import { DatasetCore } from '@rdfjs/types';
 import { parseTurtle } from 'interop-utils';
 import { Fetch } from './fetch';
 

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -21,6 +21,7 @@
     "n3": "^1.10.0"
   },
   "devDependencies": {
-    "@types/n3": "^1.8.0"
+    "@rdfjs/types": "^1.0.1",
+    "@types/n3": "^1.10.0"
   }
 }

--- a/packages/data-model/src/data-registration.ts
+++ b/packages/data-model/src/data-registration.ts
@@ -1,4 +1,4 @@
-import { DatasetCore } from 'rdf-js';
+import { DatasetCore } from '@rdfjs/types';
 import { getOneMatchingQuad } from 'interop-utils';
 import { INTEROP } from 'interop-namespaces';
 

--- a/packages/namespaces/package.json
+++ b/packages/namespaces/package.json
@@ -19,6 +19,7 @@
     "n3": "^1.10.0"
   },
   "devDependencies": {
-    "@types/n3": "^1.8.0"
+    "@rdfjs/types": "^1.0.1",
+    "@types/n3": "^1.10.0"
   }
 }

--- a/packages/namespaces/src/builder.ts
+++ b/packages/namespaces/src/builder.ts
@@ -1,5 +1,5 @@
 import { DataFactory } from 'n3';
-import { NamedNode } from 'rdf-js';
+import { NamedNode } from '@rdfjs/types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export function buildNamespace(base: string): any {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,6 +19,7 @@
     "n3": "^1.10.0"
   },
   "devDependencies": {
-    "@types/n3": "^1.8.0"
+    "@rdfjs/types": "^1.0.1",
+    "@types/n3": "^1.10.0"
   }
 }

--- a/packages/utils/src/match.ts
+++ b/packages/utils/src/match.ts
@@ -1,4 +1,4 @@
-import { Term, Quad, DatasetCore } from 'rdf-js';
+import { Term, Quad, DatasetCore } from '@rdfjs/types';
 
 /**
  *

--- a/packages/utils/src/turtle-parser.ts
+++ b/packages/utils/src/turtle-parser.ts
@@ -1,4 +1,4 @@
-import { Quad, DatasetCore } from 'rdf-js';
+import { Quad, DatasetCore } from '@rdfjs/types';
 import {
   Store, Parser, DataFactory,
 } from 'n3';
@@ -10,8 +10,7 @@ import {
  */
 
 export const parseTurtle = async (text: string, source = ''): Promise<DatasetCore> => {
-  // TODO (angel) remove the forced type coercion once @types/n3@1.10 is released
-  const store = new Store() as unknown as DatasetCore;
+  const store = new Store();
   return new Promise((resolve, reject) => {
     const parser = new Parser();
     parser.parse(text, (error: Error, quad: Quad) => {


### PR DESCRIPTION
Now we will depend on latest
* `"n3": "^1.10.0"`
* `"@types/n3": "^1.10.0"`
* `"@rdfjs/types": "^1.0.1"`