### PR TITLE
test-utils: fetch mock using snippets from the primer

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -6,5 +6,8 @@ module.exports = {
   collectCoverage: false,
   transform: {
     '^.+\\.ts$': 'ts-jest'
-  }
+  },
+  setupFilesAfterEnv: [
+    '../../setup-jest.js'
+  ]
 };

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -2,12 +2,10 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testRegex: '/test/.*-test.ts$',
-  moduleFileExtensions: [ 'js', 'ts' ],
+  moduleFileExtensions: ['js', 'ts'],
   collectCoverage: false,
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
-  setupFilesAfterEnv: [
-    '../../setup-jest.js'
-  ]
+  setupFilesAfterEnv: ['../../setup-jest.js']
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-plugin-monorepo": "^0.3.2",
     "husky": "^6.0.0",
     "jest": "^26.6.3",
+    "jest-rdf": "^1.6.0",
     "lerna": "^4.0.0",
     "prettier": "^2.3.0",
     "pretty-quick": "^3.1.0",

--- a/packages/namespaces/src/index.ts
+++ b/packages/namespaces/src/index.ts
@@ -3,3 +3,4 @@ import { buildNamespace } from './builder';
 export { buildNamespace } from './builder';
 
 export const INTEROP = buildNamespace('http://www.w3.org/ns/solid/interop#');
+export const RDF = buildNamespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');

--- a/packages/test-utils/jest.config.js
+++ b/packages/test-utils/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: '../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.json'
+    }
+  }
+};

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -16,11 +16,11 @@
     "clean": "rimraf dist tsconfig.tsbuildinfo"
   },
   "dependencies": {
-    "interop-utils": "^0.1.0",
-    "data-interoperability-panel": "*"
+    "data-interoperability-panel": "elf-pavlik/data-interoperability-panel#77d00db",
+    "interop-utils": "^0.1.0"
   },
   "devDependencies": {
     "@types/n3": "^1.8.0",
-    "@types/rdf-js": "^4.0.1"
+    "@rdfjs/types": "^1.0.1"
   }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "interop-test-utils",
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "author": "Ángel Araya <angel.araya@janeirodigital.com>",
+  "homepage": "",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "directories": {
+    "lib": "src",
+    "test": "test"
+  },
+  "scripts": {
+    "build": "tsc -b .",
+    "test": "jest",
+    "clean": "rimraf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "interop-utils": "^0.1.0",
+    "data-interoperability-panel": "*"
+  },
+  "devDependencies": {
+    "@types/n3": "^1.8.0",
+    "@types/rdf-js": "^4.0.1"
+  }
+}

--- a/packages/test-utils/src/desc.d.ts
+++ b/packages/test-utils/src/desc.d.ts
@@ -1,0 +1,1 @@
+declare module 'data-interoperability-panel';

--- a/packages/test-utils/src/fetch-mock.ts
+++ b/packages/test-utils/src/fetch-mock.ts
@@ -1,6 +1,5 @@
 import { DatasetCore } from '@rdfjs/types';
 import { parseTurtle } from 'interop-utils';
-//@ts-ignore
 import * as data from 'data-interoperability-panel';
 
 export async function fetch(url: string): Promise<DatasetCore> {

--- a/packages/test-utils/src/fetch-mock.ts
+++ b/packages/test-utils/src/fetch-mock.ts
@@ -1,0 +1,9 @@
+import { DatasetCore } from 'rdf-js'
+import { parseTurtle } from 'interop-utils'
+//@ts-ignore
+import * as data from 'data-interoperability-panel'
+
+
+export async function fetch (url: string): Promise<DatasetCore> {
+  return await parseTurtle(data[url], url)
+}

--- a/packages/test-utils/src/fetch-mock.ts
+++ b/packages/test-utils/src/fetch-mock.ts
@@ -5,5 +5,9 @@ import * as data from 'data-interoperability-panel'
 
 
 export async function fetch (url: string): Promise<DatasetCore> {
-  return parseTurtle(data[url], url)
+
+  // strip fragment
+  const strippedUrl = url.replace(/#.*$/, '')
+
+  return parseTurtle(data[strippedUrl], strippedUrl)
 }

--- a/packages/test-utils/src/fetch-mock.ts
+++ b/packages/test-utils/src/fetch-mock.ts
@@ -1,9 +1,9 @@
-import { DatasetCore } from 'rdf-js'
+import { DatasetCore } from '@rdfjs/types'
 import { parseTurtle } from 'interop-utils'
 //@ts-ignore
 import * as data from 'data-interoperability-panel'
 
 
 export async function fetch (url: string): Promise<DatasetCore> {
-  return await parseTurtle(data[url], url)
+  return parseTurtle(data[url], url)
 }

--- a/packages/test-utils/src/fetch-mock.ts
+++ b/packages/test-utils/src/fetch-mock.ts
@@ -1,13 +1,11 @@
-import { DatasetCore } from '@rdfjs/types'
-import { parseTurtle } from 'interop-utils'
+import { DatasetCore } from '@rdfjs/types';
+import { parseTurtle } from 'interop-utils';
 //@ts-ignore
-import * as data from 'data-interoperability-panel'
+import * as data from 'data-interoperability-panel';
 
-
-export async function fetch (url: string): Promise<DatasetCore> {
-
+export async function fetch(url: string): Promise<DatasetCore> {
   // strip fragment
-  const strippedUrl = url.replace(/#.*$/, '')
+  const strippedUrl = url.replace(/#.*$/, '');
 
-  return parseTurtle(data[strippedUrl], strippedUrl)
+  return parseTurtle(data[strippedUrl], strippedUrl);
 }

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './fetch-mock'

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,1 +1,1 @@
-export * from './fetch-mock'
+export * from './fetch-mock';

--- a/packages/test-utils/test/fetch-mock-test.ts
+++ b/packages/test-utils/test/fetch-mock-test.ts
@@ -1,5 +1,12 @@
 import { fetch } from '../src/fetch-mock'
 
+
+test('should strip fragment', async () => {
+  const url = 'https://alice.example/#id'
+  const dataset = await(fetch(url))
+  expect(dataset.size).toBeGreaterThan(0)
+})
+
 test('should get parsed data', async () => {
   const url = 'https://alice.example/'
   const dataset = await(fetch(url))

--- a/packages/test-utils/test/fetch-mock-test.ts
+++ b/packages/test-utils/test/fetch-mock-test.ts
@@ -1,0 +1,10 @@
+import { fetch } from '../src/fetch-mock'
+
+test('should get parsed data', async () => {
+  const url = 'https://alice.example/'
+  const dataset = await(fetch(url))
+  expect(dataset.size).toBeGreaterThan(0)
+  for (const quad of dataset) {
+    expect(quad.graph.value).toEqual(url)
+  }
+})

--- a/packages/test-utils/test/fetch-mock-test.ts
+++ b/packages/test-utils/test/fetch-mock-test.ts
@@ -4,6 +4,9 @@ test('should strip fragment', async () => {
   const url = 'https://alice.example/#id';
   const dataset = await fetch(url);
   expect(dataset.size).toBeGreaterThan(0);
+  for (const quad of dataset) {
+    expect(quad.graph.value).toEqual('https://alice.example/');
+  }
 });
 
 test('should get parsed data', async () => {

--- a/packages/test-utils/test/fetch-mock-test.ts
+++ b/packages/test-utils/test/fetch-mock-test.ts
@@ -1,17 +1,16 @@
-import { fetch } from '../src/fetch-mock'
-
+import { fetch } from '../src/fetch-mock';
 
 test('should strip fragment', async () => {
-  const url = 'https://alice.example/#id'
-  const dataset = await(fetch(url))
-  expect(dataset.size).toBeGreaterThan(0)
-})
+  const url = 'https://alice.example/#id';
+  const dataset = await fetch(url);
+  expect(dataset.size).toBeGreaterThan(0);
+});
 
 test('should get parsed data', async () => {
-  const url = 'https://alice.example/'
-  const dataset = await(fetch(url))
-  expect(dataset.size).toBeGreaterThan(0)
+  const url = 'https://alice.example/';
+  const dataset = await fetch(url);
+  expect(dataset.size).toBeGreaterThan(0);
   for (const quad of dataset) {
-    expect(quad.graph.value).toEqual(url)
+    expect(quad.graph.value).toEqual(url);
   }
-})
+});

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+  },
+  "include": [ "src" ]
+}

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "src"
   },
-  "include": [ "src" ]
+  "include": ["src"]
 }

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,0 +1,1 @@
+require('jest-rdf');


### PR DESCRIPTION
for now it depends on
``` json
"data-interoperability-panel": "elf-pavlik/data-interoperability-panel#77d00db"
```
until we can catch up with https://github.com/solid/data-interoperability-panel/pull/122

draft PR which I will make in the moment already is taking advantage of this functionality, it should also help to resolve #5 