### PR TITLE
Fix predicate used to find the access consents within the registry

### DIFF
--- a/packages/data-model/src/crud/access-consent-registry.ts
+++ b/packages/data-model/src/crud/access-consent-registry.ts
@@ -17,7 +17,7 @@ export class CRUDAccessConsentRegistry extends CRUDContainer {
   }
 
   get accessConsents(): AsyncIterable<ReadableAccessConsent> {
-    const accessConsentPattern = [DataFactory.namedNode(this.iri), INTEROP.hasAccessConsent];
+    const accessConsentPattern = [DataFactory.namedNode(this.iri), INTEROP.hasRegistration];
     const accessConsentIris = this.getQuadArray(...accessConsentPattern).map((q) => q.object.value);
     const { factory } = this;
     return {


### PR DESCRIPTION
The Access Consent Registry shape uses `interop:hasRegistration` to link to the access consents within the registry while the library was using `interop:hasAccessConsent` which I don't think exists anymore.

The test are failing because the snippets would be incorrect but I was not able to pin down where the snippet is. I'd appreciate if you can point me to the right file.