### PR TITLE
Resolves #35

### DIFF
--- a/packages/utils/src/fetch.ts
+++ b/packages/utils/src/fetch.ts
@@ -7,6 +7,7 @@ export interface RdfRequestInit extends RequestInit {
 
 export interface RdfResponse extends Response {
   dataset(): Promise<DatasetCore>;
+  text(): Promise<string>;
 }
 
 export type WhatwgFetch = (input: RequestInfo, init?: RequestInit) => Promise<Response>;
@@ -39,7 +40,7 @@ async function unwrappedRdfFetch(
     }
     return parseTurtle(await response.text(), response.url);
   };
-  return rdfResponse;
+  return { ...rdfResponse, text: response.text };
 }
 
 export function fetchWrapper(whatwgFetch: WhatwgFetch): RdfFetch {

--- a/packages/utils/src/fetch.ts
+++ b/packages/utils/src/fetch.ts
@@ -40,7 +40,8 @@ async function unwrappedRdfFetch(
     }
     return parseTurtle(await response.text(), response.url);
   };
-  return { ...rdfResponse, text: response.text };
+  rdfResponse.text = response.text;
+  return rdfResponse;
 }
 
 export function fetchWrapper(whatwgFetch: WhatwgFetch): RdfFetch {


### PR DESCRIPTION
This adds an explicit assignment for the .text() as this was given issues when used with an instance of 'node-fetch' on my side, where the .text was returning undefined.

Resolves #35 