### PR TITLE
Explicitely serialize as text/turtle

### DIFF
--- a/packages/application/test/application-test.ts
+++ b/packages/application/test/application-test.ts
@@ -11,31 +11,31 @@ const webId = 'https://alice.example/#id';
 const linkString = `
   <https://projectron.example/#app>;
   anchor="https://auth.alice.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";
-  rel="http://www.w3.org/ns/solid/interop#registeredApplication"
+  rel="http://www.w3.org/ns/solid/interop#registeredAgent"
 `;
 
 test('should build application registration', async () => {
   const mocked = jest.fn(statelessFetch);
-  mocked
-    .mockResolvedValueOnce(await statelessFetch(webId))
-    .mockResolvedValueOnce({ ok: true, headers: { get: () => linkString } } as unknown as RdfResponse);
+  const responseMock = { ok: true, headers: { get: () => linkString } } as unknown as RdfResponse;
+  responseMock.clone = () => ({ ...responseMock });
+  mocked.mockResolvedValueOnce(await statelessFetch(webId)).mockResolvedValueOnce(responseMock);
   const app = await Application.build(webId, { fetch: mocked, randomUUID });
   expect(app.hasApplicationRegistration).toBeInstanceOf(ReadableApplicationRegistration);
 });
 
 test('should throw if no appliction registration', async () => {
   const mocked = jest.fn(statelessFetch);
-  mocked
-    .mockResolvedValueOnce(await statelessFetch(webId))
-    .mockResolvedValueOnce({ ok: true, headers: { get: () => '' } } as unknown as RdfResponse);
+  const responseMock = { ok: true, headers: { get: () => '' } } as unknown as RdfResponse;
+  responseMock.clone = () => ({ ...responseMock });
+  mocked.mockResolvedValueOnce(await statelessFetch(webId)).mockResolvedValueOnce(responseMock);
   expect(Application.build(webId, { fetch: mocked, randomUUID })).rejects.toThrow('support planned');
 });
 
 test('should have dataOwners getter', async () => {
   const mocked = jest.fn(statelessFetch);
-  mocked
-    .mockResolvedValueOnce(await statelessFetch(webId))
-    .mockResolvedValueOnce({ ok: true, headers: { get: () => linkString } } as unknown as RdfResponse);
+  const responseMock = { ok: true, headers: { get: () => linkString } } as unknown as RdfResponse;
+  responseMock.clone = () => ({ ...responseMock });
+  mocked.mockResolvedValueOnce(await statelessFetch(webId)).mockResolvedValueOnce(responseMock);
   const app = await Application.build(webId, { fetch: mocked, randomUUID });
   expect(app.dataOwners).toHaveLength(3);
   for (const owner of app.dataOwners) {

--- a/packages/utils/src/fetch.ts
+++ b/packages/utils/src/fetch.ts
@@ -32,7 +32,7 @@ async function unwrappedRdfFetch(
     requestInit.headers = { Accept: 'text/turtle', ...requestInit.headers };
   }
   const response = await whatwgFetch(iri, requestInit);
-  const rdfResponse = { ...response } as RdfResponse;
+  const rdfResponse = response.clone() as RdfResponse;
   rdfResponse.dataset = async function dataset() {
     const contentType = response.headers.get('Content-Type');
     if (contentType === null || !contentType.match('text/turtle')) {

--- a/packages/utils/src/link-header.ts
+++ b/packages/utils/src/link-header.ts
@@ -2,7 +2,7 @@ import LinkHeader from 'http-link-header';
 
 export function getApplicationRegistrationIri(linkHeaderText: string): string {
   const links = LinkHeader.parse(linkHeaderText).refs;
-  return links.find((link) => link.rel === 'http://www.w3.org/ns/solid/interop#registeredApplication')?.anchor;
+  return links.find((link) => link.rel === 'http://www.w3.org/ns/solid/interop#registeredAgent')?.anchor;
 }
 
 export function targetDataRegistrationLink(dataRegistrationIri: string): string {

--- a/packages/utils/src/turtle-serializer.ts
+++ b/packages/utils/src/turtle-serializer.ts
@@ -1,16 +1,29 @@
 import { DatasetCore } from '@rdfjs/types';
-import { Writer } from 'n3';
+import { DataFactory, Store, Writer } from 'n3';
+
+const trimNamedGraph = (dataset: DatasetCore): DatasetCore => {
+  const newDataset = new Store();
+
+  for (const q of dataset) {
+    newDataset.add(DataFactory.quad(q.subject, q.predicate, q.object, DataFactory.defaultGraph()));
+  }
+
+  return newDataset;
+};
 
 /**
  * Wrapper around N3.Writer to convert from callback style to Promise.
  * @param dataset DatasetCore with data to serialize
+ * @param trim Whether to trim the named graph off the dataset or not. If the dataset has a named graph and is not trimmed
+ *             the serialization will be done in trig format instead of turtle.
  */
+export const serializeTurtle = async (dataset: DatasetCore, trim = false): Promise<string> => {
+  const writer = new Writer({ format: 'text/turtle' });
 
-export const serializeTurtle = async (dataset: DatasetCore): Promise<string> => {
-  const writer = new Writer();
-  for (const quad of dataset) {
+  for (const quad of trim ? trimNamedGraph(dataset) : dataset) {
     writer.addQuad(quad);
   }
+
   return new Promise((resolve, reject) => {
     writer.end((error: Error, text: string) => {
       if (error) {

--- a/packages/utils/test/link-header-test.ts
+++ b/packages/utils/test/link-header-test.ts
@@ -4,7 +4,7 @@ describe('getApplicationRegistrationIri', () => {
   const linkHeaderText = `
     <https://projectron.example/#app>;
     anchor="https://auth.alice.example/bcf22534-0187-4ae4-b88f-fe0f9fa96659";
-    rel="http://www.w3.org/ns/solid/interop#registeredApplication"
+    rel="http://www.w3.org/ns/solid/interop#registeredAgent"
   `;
 
   test('should match correct application registration iri', () => {

--- a/packages/utils/test/turtle-serializer-test.ts
+++ b/packages/utils/test/turtle-serializer-test.ts
@@ -1,3 +1,4 @@
+import { DataFactory, Store } from 'n3';
 import { parseTurtle, serializeTurtle } from '../src';
 
 const snippet = `<https://acme.example/4d594c61-7cff-484a-a1d2-1f353ee4e1e7> a <http://www.w3.org/ns/solid/interop#DataRegistration>;
@@ -7,10 +8,42 @@ const snippet = `<https://acme.example/4d594c61-7cff-484a-a1d2-1f353ee4e1e7> a <
     <http://www.w3.org/ns/solid/interop#registeredShapeTree> <https://solidshapes.example/trees/Project>.
 `;
 
-test('should serialize dataset', async () => {
-  const dataset = await parseTurtle(snippet);
-  const text = await serializeTurtle(dataset);
-  expect(text).toMatch(snippet);
+describe('serializer', () => {
+  test('should serialize dataset', async () => {
+    const dataset = await parseTurtle(snippet);
+    const text = await serializeTurtle(dataset);
+    expect(text).toMatch(snippet);
+  });
+
+  test('should serialize dataset with stripped named graph as ttl', async () => {
+    const q = DataFactory.quad(
+      DataFactory.namedNode('s'),
+      DataFactory.namedNode('p'),
+      DataFactory.namedNode('o'),
+      DataFactory.namedNode('g')
+    );
+    const dataset = new Store([q]);
+
+    const text = await serializeTurtle(dataset, true);
+
+    expect(text).toMatch('<s> <p> <o>.');
+  });
+
+  test('should serialize dataset named graph as trig', async () => {
+    const q = DataFactory.quad(
+      DataFactory.namedNode('s'),
+      DataFactory.namedNode('p'),
+      DataFactory.namedNode('o'),
+      DataFactory.namedNode('g')
+    );
+    const dataset = new Store([q]);
+
+    const text = await serializeTurtle(dataset);
+
+    expect(text).toMatch(`<g> {
+<s> <p> <o>.
+}`);
+  });
 });
 
 test.todo('should reject for invalid dataset');

--- a/packages/utils/test/turtle-serializer-test.ts
+++ b/packages/utils/test/turtle-serializer-test.ts
@@ -41,7 +41,7 @@ describe('serializer', () => {
     const text = await serializeTurtle(dataset);
 
     expect(text).toMatch(`<g> {
-<s> <p> <o>.
+<s> <p> <o>
 }`);
   });
 });


### PR DESCRIPTION
When a named graph is given, N3.Writer will use TriG notation
inseted of turtle. From my testing this breaks authentication/authorization
when using other libraries.
