### PR TITLE
Add name and logo_uri properties to ClientIdDocument

### DIFF
--- a/packages/data-model/src/readable/client-id-document.ts
+++ b/packages/data-model/src/readable/client-id-document.ts
@@ -1,3 +1,4 @@
+import { OIDC } from '@janeirodigital/interop-namespaces';
 import { InteropFactory } from '..';
 import { ReadableResource } from './resource';
 
@@ -11,11 +12,11 @@ export class ReadableClientIdDocument extends ReadableResource {
   }
 
   get clientName(): string | undefined {
-    return this.getObject('client_name', 'https://www.w3.org/ns/solid/oidc-context.jsonld').value;
+    return this.getObject(OIDC.client_name).value;
   }
 
   get logoUri(): string | undefined {
-    return this.getObject('logo_uri', 'https://www.w3.org/ns/solid/oidc-context.jsonld').value;
+    return this.getObject(OIDC.logo_uri).value;
   }
 
   protected async bootstrap(): Promise<void> {

--- a/packages/data-model/src/readable/client-id-document.ts
+++ b/packages/data-model/src/readable/client-id-document.ts
@@ -10,6 +10,14 @@ export class ReadableClientIdDocument extends ReadableResource {
     return this.getObject('hasAccessNeedGroup')?.value;
   }
 
+  get clientName(): string | undefined {
+    return this.getObject('client_name', 'https://www.w3.org/ns/solid/oidc-context.jsonld').value;
+  }
+
+  get logoUri(): string | undefined {
+    return this.getObject('logo_uri', 'https://www.w3.org/ns/solid/oidc-context.jsonld').value;
+  }
+
   protected async bootstrap(): Promise<void> {
     await this.fetchData();
   }

--- a/packages/data-model/test/readable/client-id-document-test.ts
+++ b/packages/data-model/test/readable/client-id-document-test.ts
@@ -17,4 +17,14 @@ describe('getters', () => {
     const clientIdDocument = await factory.readable.clientIdDocument(snippetIri);
     expect(clientIdDocument.callbackEndpoint).toBe('https://projectron.example/');
   });
+
+  test('clientName', async () => {
+    const clientIdDocument = await factory.readable.clientIdDocument(snippetIri);
+    expect(clientIdDocument.clientName).toEqual('Projectron');
+  });
+
+  test('logoUri', async () => {
+    const clientIdDocument = await factory.readable.clientIdDocument(snippetIri);
+    expect(clientIdDocument.logoUri).toEqual('https://projectron.example/thumb.svg');
+  });
 });

--- a/packages/data-model/test/readable/client-id-document-test.ts
+++ b/packages/data-model/test/readable/client-id-document-test.ts
@@ -25,6 +25,6 @@ describe('getters', () => {
 
   test('logoUri', async () => {
     const clientIdDocument = await factory.readable.clientIdDocument(snippetIri);
-    expect(clientIdDocument.logoUri).toEqual('https://projectron.example/thumb.svg');
+    expect(clientIdDocument.logoUri).toEqual('https://robohash.org/https://projectron.example/?set=set3');
   });
 });

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@janeirodigital/interop-utils": "^1.0.0-rc.15",
-    "data-interoperability-panel": "elf-pavlik/data-interoperability-panel#88c2524"
+    "data-interoperability-panel": "elf-pavlik/data-interoperability-panel#52073762"
   },
   "devDependencies": {
     "@types/n3": "^1.8.0",

--- a/packages/test-utils/src/fetch-mock.ts
+++ b/packages/test-utils/src/fetch-mock.ts
@@ -1,5 +1,7 @@
 import { WhatwgFetch, RdfFetch, fetchWrapper } from '@janeirodigital/interop-utils';
-import data from 'data-interoperability-panel';
+import { readFileSync } from 'fs';
+
+const data = JSON.parse(readFileSync('../../node_modules/data-interoperability-panel/dist/index.json', 'utf-8'));
 
 async function common(url: string, options?: RequestInit, state?: { [key: string]: string }): Promise<Response> {
   // strip fragment


### PR DESCRIPTION
Add the name and logo_uri properties to the client id document so that it is available for application that are not registered yet (needed for the authorization screen on the web client).

~I assume that this adds them to the correct location, but still struggling on how to invoke it from the service. Unfortunately the class is not used outside of tests mocks in the service.~